### PR TITLE
fix file conflicts with system apr

### DIFF
--- a/SPECS/ea-apr.spec
+++ b/SPECS/ea-apr.spec
@@ -7,6 +7,7 @@
 %define prefix_lib %{prefix_dir}/%{_lib}
 %define prefix_bin %{prefix_dir}/bin
 %define prefix_inc %{prefix_dir}/include
+%define prefix_data %{prefix_dir}/share
 
 # Arches on which the multilib apr.h hack is needed:
 %define multilib_arches %{ix86} ia64 ppc ppc64 s390 s390x x86_64
@@ -84,8 +85,8 @@ make %{?_smp_mflags}
 rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
 
-mkdir -p $RPM_BUILD_ROOT/%{_datadir}/aclocal
-install -m 644 build/find_apr.m4 $RPM_BUILD_ROOT/%{_datadir}/aclocal
+mkdir -p $RPM_BUILD_ROOT/%{prefix_data}/aclocal
+install -m 644 build/find_apr.m4 $RPM_BUILD_ROOT/%{prefix_data}/aclocal
 
 # Trim exported dependecies
 sed -ri '/^dependency_libs/{s,-l(uuid|crypt) ,,g}' \
@@ -160,7 +161,7 @@ rm -rf $RPM_BUILD_ROOT
 %dir %{prefix_inc}
 %dir %{prefix_inc}/apr-%{aprver}
 %{prefix_inc}/apr-%{aprver}/*.h
-%{_datadir}/aclocal/find_apr.m4
+%{prefix_data}/aclocal/find_apr.m4
 %{_sysconfdir}/rpm/macros.%{pkgname}
 
 %changelog


### PR DESCRIPTION
file /usr/share/aclocal/find_apr.m4 from install of ea-apr-devel-1:1.5.2-6.el6.cloudlinux.x86_64 conflicts with file from package apr-devel-1.3.9-5.el6_2.cloudlinux.2.x86_64