### PR TITLE
CVE-2017-12613

### DIFF
--- a/SOURCES/apr-1.5.2-CVE-2017-12613.patch
+++ b/SOURCES/apr-1.5.2-CVE-2017-12613.patch
@@ -1,0 +1,36 @@
+diff -apruN apr-1.5.2.orig/time/unix/time.c apr-1.5.2/time/unix/time.c
+--- apr-1.5.2.orig/time/unix/time.c	2006-08-03 13:55:31.000000000 +0300
++++ apr-1.5.2/time/unix/time.c	2017-11-29 11:04:45.480356730 +0200
+@@ -142,6 +142,9 @@ APR_DECLARE(apr_status_t) apr_time_exp_g
+     static const int dayoffset[12] =
+     {306, 337, 0, 31, 61, 92, 122, 153, 184, 214, 245, 275};
+ 
++    if (xt->tm_mon < 0 || xt->tm_mon >= 12)
++        return APR_EBADDATE;
++
+     /* shift new year to 1st March in order to make leap year calc easy */
+ 
+     if (xt->tm_mon < 2)
+diff -apruN apr-1.5.2.orig/time/win32/time.c apr-1.5.2/time/win32/time.c
+--- apr-1.5.2.orig/time/win32/time.c	2012-08-12 00:04:05.000000000 +0300
++++ apr-1.5.2/time/win32/time.c	2017-11-29 11:06:10.117401454 +0200
+@@ -54,6 +54,9 @@ static void SystemTimeToAprExpTime(apr_t
+     static const int dayoffset[12] =
+     {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
+ 
++    if (tm->wMonth < 1 || tm->wMonth > 12)
++        return APR_EBADDATE;
++
+     /* Note; the caller is responsible for filling in detailed tm_usec,
+      * tm_gmtoff and tm_isdst data when applicable.
+      */
+@@ -224,6 +227,9 @@ APR_DECLARE(apr_status_t) apr_time_exp_g
+     static const int dayoffset[12] =
+     {306, 337, 0, 31, 61, 92, 122, 153, 184, 214, 245, 275};
+ 
++    if (xt->tm_mon < 0 || xt->tm_mon >= 12)
++        return APR_EBADDATE;
++
+     /* shift new year to 1st March in order to make leap year calc easy */
+ 
+     if (xt->tm_mon < 2)

--- a/SPECS/ea-apr.spec
+++ b/SPECS/ea-apr.spec
@@ -17,7 +17,7 @@ Name: %{pkgname}
 Version: 1.5.2
 
 # Doing release_prefix this way for Release allows for OBS-proof versioning, See EA-4540 for more details
-%define release_prefix 8
+%define release_prefix 9
 Release: %{release_prefix}%{?dist}.cpanel
 # ASL 2.0: everything
 # ISC: network_io/apr-1.4.6/network_io/unix/inet_?to?.c
@@ -36,6 +36,7 @@ Patch2: apr-1.2.2-locktimeout.patch
 Patch3: apr-1.2.2-libdir.patch
 Patch4: apr-1.2.7-pkgconf.patch
 Patch5: apr-1.5.2-symlink.patch
+Patch6: apr-1.5.2-CVE-2017-12613.patch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 BuildRequires: autoconf, libtool, libuuid-devel, python
 BuildRequires: ea-openssl ea-openssl-devel
@@ -66,6 +67,7 @@ C data structures and routines.
 %patch3 -p1 -b .libdir
 %patch4 -p1 -b .pkgconf
 %patch5 -p1 -b .symlink
+%patch6 -p1 -b .CVE-2017-12613
 
 export CFLAGS="-I/opt/cpanel/ea-openssl/include"
 export LDFLAGS="-L/opt/cpanel/ea-openssl/lib -R/opt/cpanel/ea-openssl/lib"
@@ -169,6 +171,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/rpm/macros.%{pkgname}
 
 %changelog
+* Wed Nov 29 2017 Dmitriy Kasyanov <dkasyanov@cloudlinux.com> - 1.5.2-9
+- CVE-2017-12613: Out-of-bounds array deref in apr_time_exp*() functions
+
 * Thu Jun 08 2017 Jacob Perkins <jacob.perkins@cpanel.net> - 1.5.2-8
 - Build against ea-openssl
 


### PR DESCRIPTION
Out-of-bounds array deref in apr_time_exp*() functions

When apr_time_exp_t or apr_os_exp_time_t arguments are passed with an
invalid month field value in APR 1.6.2 and prior, out of bounds memory
may be accessed in converting this value to an apr_time_exp_t value,
potentially revealing the contents of a different static heap value or
resulting in program termination, and may represent an information
disclosure or denial of service vulnerability to applications which call
these APR functions with unvalidated external input.